### PR TITLE
fix issue with worldcereal installation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,7 +54,7 @@ jobs:
         uses: robinraju/release-downloader@v1.1
         with:
           repository: "WorldCereal/wc-classification"
-          tag: "${{ steps.cots-versions.outputs.EWOC_CLASSIF_VERSION }}"
+          tag: "v${{ steps.cots-versions.outputs.EWOC_CLASSIF_VERSION }}"
           fileName: "worldcereal-${{ steps.cots-versions.outputs.EWOC_CLASSIF_VERSION }}.tar.gz"
           token: ${{ secrets.CS_ORG_TOKEN }}
       - name: Build Docker images

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Download Classification package
         uses: robinraju/release-downloader@v1.1
         with:
-          repository: "WorldCereal/wc_classification"
+          repository: "WorldCereal/wc-classification"
           tag: "${{ steps.cots-versions.outputs.EWOC_CLASSIF_VERSION }}"
           fileName: "worldcereal-${{ steps.cots-versions.outputs.EWOC_CLASSIF_VERSION }}.tar.gz"
           token: ${{ secrets.CS_ORG_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,66 @@
+name: Process Docker
+
+on:
+  push:
+    branches:
+    # Sequence of patterns matched against refs/tags
+    tags:
+
+jobs:
+
+  publish:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+        with:
+          registry: hfjcmwgl.gra5.container-registry.ovh.net
+          username: ${{ secrets.CS_HARBOR_USERNAME }}
+          password: ${{ secrets.CS_HARBOR_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            hfjcmwgl.gra5.container-registry.ovh.net/world-cereal/ewoc_classif
+          # Do not generate :latest tag on Git push tag
+          # See https://github.com/marketplace/actions/docker-metadata-action#latest-tag
+          flavor: |
+            latest=false
+          # generate Docker tags based on the following events/attributes
+          # See https://github.com/marketplace/actions/docker-metadata-action#tags-input
+          tags: |
+            type=ref,event=branch
+            type=ref,suffix=-{{sha}},event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          labels: |
+            EWoC
+      # Extract COTS versions from Dockerfile
+      - name: COTS Versions
+        id: cots-versions
+        run: |
+          sed -n '/^ARG/s/ARG *\(.*\)=\(.*\)/::set-output name=\1::\2/p' Dockerfile
+      - name: Download Classification package
+        uses: robinraju/release-downloader@v1.1
+        with:
+          repository: "WorldCereal/wc_classification"
+          tag: "${{ steps.cots-versions.outputs.EWOC_CLASSIF_VERSION }}"
+          fileName: "worldcereal-${{ steps.cots-versions.outputs.EWOC_CLASSIF_VERSION }}.tar.gz"
+          token: ${{ secrets.CS_ORG_TOKEN }}
+      - name: Build Docker images
+        uses: docker/build-push-action@v2.5.0
+        with:
+          push: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ ENV EWOC_CLASSIF_VENV=/opt/ewoc_classif
 RUN python3 -m venv ${EWOC_CLASSIF_VENV}
 RUN source ${EWOC_CLASSIF_VENV}/bin/activate
 RUN ${EWOC_CLASSIF_VENV}/bin/pip install --upgrade "pip<20.3"
-RUN ${EWOC_CLASSIF_VENV}/bin/pip install --no-cache-dir -v --extra-index-url https://artifactory.vgt.vito.be/api/pypi/python-packages/simple worldcereal>=${EWOC_CLASSIF_VERSION} 
+ADD https://artifactory.vgt.vito.be/python-packages/worldcereal/0.3.2a1/worldcereal-0.3.2a1.20210916.256_develop-py3-none-any.whl /tmp
+RUN ${EWOC_CLASSIF_VENV}/bin/pip install --no-cache-dir -v --extra-index-url https://artifactory.vgt.vito.be/api/pypi/python-packages/simple /tmp/worldcereal-0.3.2a1.20210916.256_develop-py3-none-any.whl
 
 ENV GDAL_CACHEMAX 16
 ENV LOGURU_FORMAT='<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <cyan>{thread}</cyan>:<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>'

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN python3 -m venv ${EWOC_CLASSIF_VENV}
 RUN source ${EWOC_CLASSIF_VENV}/bin/activate
 RUN ${EWOC_CLASSIF_VENV}/bin/pip install --upgrade pip
 COPY worldcereal-${EWOC_CLASSIF_VERSION}.tar.gz /tmp
-RUN ${EWOC_CLASSIF_VENV}/bin/pip install /tmp/worldcereal-0.3.3a1.tar.gz --no-cache-dir \
+RUN ${EWOC_CLASSIF_VENV}/bin/pip install /tmp/worldcereal-${EWOC_CLASSIF_VERSION}.tar.gz --no-cache-dir \
     --extra-index-url https://artifactory.vgt.vito.be/api/pypi/python-packages/simple
 
 ENV GDAL_CACHEMAX 16

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV EWOC_CLASSIF_VENV=/opt/ewoc_classif_venv
 RUN python3 -m venv ${EWOC_CLASSIF_VENV}
 RUN source ${EWOC_CLASSIF_VENV}/bin/activate
 RUN ${EWOC_CLASSIF_VENV}/bin/pip install --upgrade pip
-COPY worldcereal--${EWOC_CLASSIF_VERSION}.tar.gz /tmp
+COPY worldcereal-${EWOC_CLASSIF_VERSION}.tar.gz /tmp
 RUN ${EWOC_CLASSIF_VENV}/bin/pip install /tmp/worldcereal-0.3.3a1.tar.gz --no-cache-dir \
     --extra-index-url https://artifactory.vgt.vito.be/api/pypi/python-packages/simple
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,15 @@ RUN apt-get update -y \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 
-ARG EWOC_CLASSIF_VERSION=0.3.2a1.20210916.256-develop
+ARG EWOC_CLASSIF_VERSION=0.3.2.post1
 LABEL EWOC_CLASSIF="${EWOC_CLASSIF_VERSION}"
-ENV EWOC_CLASSIF_VENV=/opt/ewoc_classif
+ENV EWOC_CLASSIF_VENV=/opt/ewoc_classif_venv
 RUN python3 -m venv ${EWOC_CLASSIF_VENV}
 RUN source ${EWOC_CLASSIF_VENV}/bin/activate
-RUN ${EWOC_CLASSIF_VENV}/bin/pip install --upgrade "pip<20.3"
-ADD https://artifactory.vgt.vito.be/python-packages/worldcereal/0.3.2a1/worldcereal-0.3.2a1.20210916.256_develop-py3-none-any.whl /tmp
-RUN ${EWOC_CLASSIF_VENV}/bin/pip install --no-cache-dir -v --extra-index-url https://artifactory.vgt.vito.be/api/pypi/python-packages/simple /tmp/worldcereal-0.3.2a1.20210916.256_develop-py3-none-any.whl
+RUN ${EWOC_CLASSIF_VENV}/bin/pip install --upgrade pip
+COPY worldcereal--${EWOC_CLASSIF_VERSION}.tar.gz /tmp
+RUN ${EWOC_CLASSIF_VENV}/bin/pip install /tmp/worldcereal-0.3.3a1.tar.gz --no-cache-dir \
+    --extra-index-url https://artifactory.vgt.vito.be/api/pypi/python-packages/simple
 
 ENV GDAL_CACHEMAX 16
 ENV LOGURU_FORMAT='<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <cyan>{thread}</cyan>:<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>'


### PR DESCRIPTION
fix #3 

I cannot access to 0.3.2a1 packages via pip and the current artifactory address: https://artifactory.vgt.vito.be/api/pypi/python-packages/simple It get only 0.3.1 series (0.3.1.20210920.122)

the packages 0.3.2a1 is available in https://artifactory.vgt.vito.be/webapp/#/artifacts/browse/simple/General/python-packages-public-snapshot/worldcereal/0.3.2a1 note the snapshot in the address.

I finally retrieve manually the package but it is not optimal! @jdries  can you take a look to this point and help me please .

With this fix I succeed to execute `docker run -it ewocclassif:latest --help`